### PR TITLE
Handle root expansion for non-zero mmcblk devices

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -104,18 +104,19 @@ cat <<'EOFRC' > "$mountdir/etc/rc.local"
 do_expand_rootfs() {
   ROOT_PART=$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
 
-  PART_NUM=${ROOT_PART#mmcblk0p}
-  if [ "$PART_NUM" = "$ROOT_PART" ]; then
+  ROOT_DEV=${ROOT_PART%p*}
+  PART_NUM=${ROOT_PART#${ROOT_DEV}p}
+  if [ "$ROOT_DEV" = "$ROOT_PART" ]; then
     echo "$ROOT_PART is not an SD card. Don't know how to expand"
     return 0
   fi
 
   # Get the starting offset of the root partition
-  PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
+  PART_START=$(parted /dev/${ROOT_DEV} -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
   [ "$PART_START" ] || return 1
   # Return value will likely be error for fdisk as it fails to reload the
   # partition table because the root fs is mounted
-  fdisk /dev/mmcblk0 <<EOF
+  fdisk /dev/${ROOT_DEV} <<EOF
 p
 d
 $PART_NUM


### PR DESCRIPTION
## Summary
- Detect root device dynamically instead of assuming mmcblk0
- Expand the correct mmcblkN partition during first boot

## Testing
- `bash -n pishrink.sh`
- `bash pishrink.sh -h`
- `shellcheck pishrink.sh` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b165a4268883208f30af3edf065a7a